### PR TITLE
perf: implement pagination for profiles query

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,10 @@ import {
 
 export default async function Home() {
   const supabase = await createClient();
-  const { data: profiles, error } = await supabase.from('profiles').select('*');
+  const { data: profiles, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .range(0, 9);
 
   if (error) {
     console.error('Error fetching profiles:', error);


### PR DESCRIPTION
Add `.range(0, 9)` to the profiles query in `app/page.tsx` to prevent fetching an unbounded number of rows from the database. This improves performance by reducing data transfer, memory usage, and rendering time.